### PR TITLE
[FW-946]: swipe view requires apply layout on parent view

### DIFF
--- a/src/ui/dialog/dialog.ios.ts
+++ b/src/ui/dialog/dialog.ios.ts
@@ -14,7 +14,7 @@ export default class DialogIOS extends NativeMobileComponent implements IDialog 
     this.dialogView = new FlexLayout();
     this.dialogView.nativeObject.frame = __SF_UIScreen.mainScreen().bounds;
     this.dialogView.backgroundColor = Color.create(DEFAULT_TRANSLUCENCY, 0, 0, 0);
-    this.dialogView.id = String(DialogIOS.iOS.ID);
+    this.dialogView.id = DialogIOS.iOS.ID;
 
     this.dialogView.applyLayout = () => this.dialogView.nativeObject.yoga.applyLayoutPreservingOrigin(true);
     this.dialogView.nativeObject.addObserver(() => {

--- a/src/ui/swipeview/swipeview.ios.ts
+++ b/src/ui/swipeview/swipeview.ios.ts
@@ -47,6 +47,7 @@ export default class SwipeViewIOS<TEvent extends string = SwipeViewEvents, TNati
     return super.createNativeObject();
   }
   preConstruct(params?: TProps) {
+    this.id = 101;
     this.transactionIndex = 0;
     this._currentIndex = 0;
     this.currentState = SwipeViewState.IDLE;

--- a/src/ui/swipeview/swipeview.ios.ts
+++ b/src/ui/swipeview/swipeview.ios.ts
@@ -47,7 +47,6 @@ export default class SwipeViewIOS<TEvent extends string = SwipeViewEvents, TNati
     return super.createNativeObject();
   }
   preConstruct(params?: TProps) {
-    this.id = 101;
     this.transactionIndex = 0;
     this._currentIndex = 0;
     this.currentState = SwipeViewState.IDLE;

--- a/src/ui/view/view.ts
+++ b/src/ui/view/view.ts
@@ -323,7 +323,7 @@ export interface IViewProps<TProps extends MobileOSProps<ViewIOSProps, ViewAndro
    * @member UI.View
    * @since 0.1
    */
-  id: string;
+  id: number;
   /**
    * Gets/sets test id for view. resource-id for android; accessibilityIdentifier for iOS.
    *
@@ -662,7 +662,7 @@ export interface IViewProps<TProps extends MobileOSProps<ViewIOSProps, ViewAndro
    */
   maskedBorders: Border[];
   /**
-   * The color of the shadow. 
+   * The color of the shadow.
    * {@link UI.View.ios#masksToBounds} property must be false for shadow on iOS.
    * On Android, this property only works on Android 9 and above.
    *
@@ -1149,7 +1149,7 @@ export declare class AbstractView<TEvent extends string = ViewEvents, TNative = 
   borderTopRightRadius: number;
   borderBottomRightRadius: number;
   borderBottomLeftRadius: number;
-  id: string;
+  id: number;
   testId: string;
   visible: boolean;
   rotation: number;

--- a/src/ui/viewgroup/viewgroup.android.ts
+++ b/src/ui/viewgroup/viewgroup.android.ts
@@ -61,7 +61,7 @@ export default class ViewGroupAndroid<TEvent extends string = ViewGroupEvents, T
   getChildList() {
     return Object.values(this.childViews);
   }
-  findChildById(id) {
+  findChildById(id: number) {
     return this.childViews[id] ? this.childViews[id] : null;
   }
   toString() {

--- a/src/ui/viewgroup/viewgroup.ios.ts
+++ b/src/ui/viewgroup/viewgroup.ios.ts
@@ -49,6 +49,13 @@ export default class ViewGroupIOS<TEvent extends string = ViewGroupEvents, TNati
     this._childs[uniqueId] = view;
     this.nativeObject.addSubview(view.nativeObject);
     __SF_UIView.applyToRootView();
+
+    // SwipeView working with UIPageViewController which has 'inaccessible views'.
+    // When user removes/adds or change style of the SwipeView, applyLayout needs to be called for parent view
+    // @ts-ignore
+    if (view.id === 101) {
+      this.applyLayout();
+    }
   }
 
   private getAndroidProps() {

--- a/src/ui/viewgroup/viewgroup.ios.ts
+++ b/src/ui/viewgroup/viewgroup.ios.ts
@@ -89,7 +89,7 @@ export default class ViewGroupIOS<TEvent extends string = ViewGroupEvents, TNati
     return Object.values(this._childs);
   }
 
-  findChildById(id: string) {
+  findChildById(id: number) {
     for (const prop in this._childs) {
       if (this._childs[prop].id === id) {
         return this._childs[prop];

--- a/src/ui/viewgroup/viewgroup.ios.ts
+++ b/src/ui/viewgroup/viewgroup.ios.ts
@@ -52,8 +52,8 @@ export default class ViewGroupIOS<TEvent extends string = ViewGroupEvents, TNati
 
     // SwipeView working with UIPageViewController which has 'inaccessible views'.
     // When user removes/adds or change style of the SwipeView, applyLayout needs to be called for parent view
-    // @ts-ignore
-    if (view.id === 101) {
+    // TODO: Investigate why swipeview parents requires apply layout (FW-1048)
+    if (view.constructor.name === 'SwipeViewIOS') {
       this.applyLayout();
     }
   }

--- a/src/ui/viewgroup/viewgroup.ts
+++ b/src/ui/viewgroup/viewgroup.ts
@@ -110,7 +110,7 @@ export interface IViewGroup<
    * @ios
    * @since 0.1
    */
-  findChildById(id: string): void;
+  findChildById(id: number): void;
   /**
    * This event is called when a view added to this view's hierarchy.
    *
@@ -185,7 +185,7 @@ export declare class AbstractViewGroup<TEvent extends string = ViewGroupEvents, 
   removeAll(): void;
   getChildCount(): number;
   getChildList(): IView[];
-  findChildById(id: string): void;
+  findChildById(id: number): void;
   onViewAdded: (view: IView) => void;
   onViewRemoved: (view: any) => void;
 }


### PR DESCRIPTION
Swipe View has inaccessible views, So the logic calling apply layout on root view does not work here.

I tag SwipeView in order to filter required views who needs to call apply layout for parent views. 
Do you think we can use this approach eliminate performance issues? @myalcinkuru